### PR TITLE
(WIP) Get XHGui working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-xhgui
+xhgui/config/config.php

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "xhgui"]
+	path = xhgui
+	url = https://github.com/perftools/xhgui.git

--- a/modules/xhprof/manifests/init.pp
+++ b/modules/xhprof/manifests/init.pp
@@ -34,7 +34,7 @@ class xhprof (
 	}
 
 	file { [
-			"/etc/php/${config[php]}/fpm/conf.d/xhgui.ini",
+		"/etc/php/${config[php]}/fpm/conf.d/xhgui.ini",
 		"/etc/php/${config[php]}/cli/conf.d/xhgui.ini",
 	]:
 		ensure  => $file,

--- a/modules/xhprof/manifests/init.pp
+++ b/modules/xhprof/manifests/init.pp
@@ -33,6 +33,19 @@ class xhprof (
 		notify  => Service["php${config[php]}-fpm"]
 	}
 
+	file { [
+			"/etc/php/${config[php]}/fpm/conf.d/xhgui.ini",
+		"/etc/php/${config[php]}/cli/conf.d/xhgui.ini",
+	]:
+		ensure  => $file,
+		content => template('xhprof/xhgui.ini.erb'),
+		owner   => 'root',
+		group   => 'root',
+		mode    => '0644',
+		require => [ Package["php${config[php]}-fpm"] ],
+		notify  => Service["php${config[php]}-fpm"]
+	}
+
 	if ( latest == $package ) {
 		exec { 'download xhprof and build it':
 			path    => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
@@ -76,7 +89,12 @@ class xhprof (
 		notify  => Service["php$php_version-fpm"]
 	}
 
-		package { "mongodb":
+	package { "mongodb":
 		ensure  => $package,
+	}
+
+	file { '/vagrant/extensions/xhprof/xhgui/config/config.php':
+		content => template('xhprof/config.php.erb'),
+		require => Exec['install xhgui']
 	}
 }

--- a/modules/xhprof/manifests/init.pp
+++ b/modules/xhprof/manifests/init.pp
@@ -1,7 +1,8 @@
 # A Chassis extension that installs XHProf and XHGui
 class xhprof (
   $config,
-  $path = '/vagrant/extensions/xhprof'
+  $path = '/vagrant/extensions/xhprof',
+  $php_version  = $config[php],
 ) {
 
 	if ( ! empty( $config[disabled_extensions] ) and 'chassis/xhprof' in $config[disabled_extensions] ) {
@@ -60,5 +61,22 @@ class xhprof (
 			recurse => true,
 			force   => true
 		}
+	}
+
+	exec { 'install xhgui':
+		path => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
+		cwd => '/vagrant/extensions/xhprof/xhgui/',
+		command => 'php install.php',
+		require => [ Package["php$php_version-fpm"] ]
+	}
+
+	package { "php$php_version-mongodb":
+		ensure  => $package,
+		require => [ Package["php$php_version-cli"], Package["php$php_version-fpm"] ],
+		notify  => Service["php$php_version-fpm"]
+	}
+
+		package { "mongodb":
+		ensure  => $package,
 	}
 }

--- a/modules/xhprof/templates/config.php.erb
+++ b/modules/xhprof/templates/config.php.erb
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Default configuration for Xhgui
+ */
+return array(
+    'debug' => false,
+    'mode' => 'development',
+
+    // Can be either mongodb or file.
+    /* 
+    'save.handler' => 'file',
+    'save.handler.filename' => dirname(__DIR__) . '/cache/' . 'xhgui.data.' . microtime(true) . '_' . substr(md5($url), 0, 6),
+    */
+    'save.handler' => 'mongodb',
+
+    // Needed for file save handler. Beware of file locking. You can adujst this file path 
+    // to reduce locking problems (eg uniqid, time ...)
+    //'save.handler.filename' => __DIR__.'/../data/xhgui_'.date('Ymd').'.dat',
+    'db.host' => 'mongodb://127.0.0.1:27017',
+    'db.db' => 'xhprof',
+
+    // Allows you to pass additional options like replicaSet to MongoClient.
+    // 'username', 'password' and 'db' (where the user is added)
+    'db.options' => array(),
+    'templates.path' => dirname(__DIR__) . '/src/templates',
+    'date.format' => 'M jS H:i:s',
+    'detail.count' => 6,
+    'page.limit' => 25,
+
+    // Profile 1 in 100 requests.
+    // You can return true to profile every request.
+    'profiler.enable' => function() {
+        return true;
+    },
+
+    'profiler.simple_url' => function($url) {
+        return preg_replace('/\=\d+/', '', $url);
+    },
+
+    'profiler.options' => array(),
+
+);


### PR DESCRIPTION
This starts work on #11. I've gotta come back and revisit it tomorrow to make some paths dynamic and also make sure the `xhgui.ini` auto_prepend_file is added after WordPress has been installed. 

I might also need to add a script to run the following:
```
$ mongo
> use xhprof
> db.results.ensureIndex( { 'meta.SERVER.REQUEST_TIME' : -1 } )
> db.results.ensureIndex( { 'profile.main().wt' : -1 } )
> db.results.ensureIndex( { 'profile.main().mu' : -1 } )
> db.results.ensureIndex( { 'profile.main().cpu' : -1 } )
> db.results.ensureIndex( { 'meta.url' : 1 } )
> db.results.ensureIndex( { 'meta.simple_url' : 1 } )
```